### PR TITLE
Prevent forging replies

### DIFF
--- a/LibTrinityCore-1.0/LibTrinityCore-1.0.lua
+++ b/LibTrinityCore-1.0/LibTrinityCore-1.0.lua
@@ -47,6 +47,7 @@ frame:SetScript("OnEvent", function(self, event, prefix, message, channel, sende
   end
   assert(event == "CHAT_MSG_ADDON")
   if prefix ~= "TrinityCore" then return end
+  if sender ~= UnitName("player") then return end
   if isTrinity == nil then
     if message == "p0000" then
       isTrinity = false


### PR DESCRIPTION
Sender can be the player only if the message was sent by the client itself or the server.

For example a douche player could be spamming p0000 to players, which could maybe fail the initialization of the addon. This will prevent such behavior since the message sender must be server or the player itself.